### PR TITLE
Added link wrapper, copied from base MediaTransformOutput class

### DIFF
--- a/NativeSvgHandler.php
+++ b/NativeSvgHandler.php
@@ -90,6 +90,35 @@ class SvgImage extends MediaTransformOutput {
 
         $alt = empty( $options['alt'] ) ? '' : $options['alt'];
 
+        $query = empty( $options['desc-query'] ) ? '' : $options['desc-query'];
+
+        if ( !empty( $options['custom-url-link'] ) ) {
+            $linkAttribs = array( 'href' => $options['custom-url-link'] );
+            if ( !empty( $options['title'] ) ) {
+                $linkAttribs['title'] = $options['title'];
+            }
+            if ( !empty( $options['custom-target-link'] ) ) {
+                $linkAttribs['target'] = $options['custom-target-link'];
+            } elseif ( !empty( $options['parser-extlink-target'] ) ) {
+                $linkAttribs['target'] = $options['parser-extlink-target'];
+            }
+            if ( !empty( $options['parser-extlink-rel'] ) ) {
+                $linkAttribs['rel'] = $options['parser-extlink-rel'];
+            }
+        } elseif ( !empty( $options['custom-title-link'] ) ) {
+            $title = $options['custom-title-link'];
+            $linkAttribs = array(
+                'href' => $title->getLinkURL(),
+                'title' => empty( $options['title'] ) ? $title->getFullText() : $options['title']
+            );
+        } elseif ( !empty( $options['desc-link'] ) ) {
+            $linkAttribs = $this->getDescLinkAttribs( empty( $options['title'] ) ? null : $options['title'], $query );
+        } elseif ( !empty( $options['file-link'] ) ) {
+            $linkAttribs = array( 'href' => $this->file->getURL() );
+        } else {
+            $linkAttribs = false;
+        }
+
         $attribs = array(
             'alt' => $alt,
             'src' => $this->url,
@@ -102,6 +131,7 @@ class SvgImage extends MediaTransformOutput {
         if ( !empty( $options['img-class'] ) ) {
             $attribs['class'] = $options['img-class'];
         }
-        return Xml::element('img', $attribs);
+
+        return $this->linkWrap( $linkAttribs, Xml::element( 'img', $attribs ) );
     }
 }


### PR DESCRIPTION
A few people (myself included) wanted svg images to provide links just like other image media; I copied over the relevant bit of code from the base MediaTransformOutput class (https://doc.wikimedia.org/mediawiki-core/master/php/html/MediaTransformOutput_8php_source.html) to add that functionality. It seems to work fine in my application, but I haven't tested extensively -- ymmv.
