### PR TITLE
Respect $wgNativeSvgHandlerEnableLinks = false

### DIFF
--- a/NativeSvgHandler.php
+++ b/NativeSvgHandler.php
@@ -61,12 +61,13 @@ class NativeSvgHandler extends SvgHandler {
             return new TransformParameterError( $params );
         }
 
-		if(!isset($wgNativeSvgHandlerEnableLinks) || $wgNativeSvgHandlerEnableLinks) {
-			return new ThumbnailImage($image, $image->getURL(), $params['width'],
+        global $wgNativeSvgHandlerEnableLinks;
+        if(!isset($wgNativeSvgHandlerEnableLinks) || $wgNativeSvgHandlerEnableLinks) {
+            return new ThumbnailImage($image, $image->getURL(), $params['width'],
+                                      $params['height'], $image->getPath() );
+        }
+        return new SvgImage($image, $image->getURL(), $params['width'],
                             $params['height'], $image->getPath() );
-		}
-		return new SvgImage($image, $image->getURL(), $params['width'],
-                            $params['height'], $image->getPath() );		
     }
 
     function getThumbType($ext, $mime, $params = null) {


### PR DESCRIPTION
Adds the global declaration to access $wgNativeSvgHandlerEnableLinks inside the function.

The rest is just tab to space conversion to match the format in the rest of the file.